### PR TITLE
Add support for other `ServletEnvironment` instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ public class ExampleConfiguration extends Configuration {
 
 Add a `WebBundle` to the `Boostrap` object in your `initialize` method:
 ```java
-bootstrap.addBundle(new WebBundle<ExampleConfiguration>() {
+bootstrap.addBundle(new WebBundle<>() {
     @Override
     public WebConfiguration getWebConfiguration(final ExampleConfiguration configuration) {
         return configuration.getWebConfiguration();
+    }
+
+    // Optional: Override Servlet environment to apply the configuration to the admin servlets
+    @Override
+    protected ServletEnvironment getServletEnvironment(Environment environment) {
+        return environment.admin();
     }
 });
 ```
@@ -78,7 +84,7 @@ This minimal config results in the following:
 Support for CORS or CSP require additional configuration.
 
 ## Maven Artifacts
-This project is available on Maven Central. To add it to your project simply add the following dependencies to your 
+This project is available on Maven Central. To add it to your project simply add the following dependencies to your
 `pom.xml`:
 ```xml
 <dependency>

--- a/src/main/java/io/dropwizard/web/WebBundle.java
+++ b/src/main/java/io/dropwizard/web/WebBundle.java
@@ -4,6 +4,7 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.ConfiguredBundle;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
+import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.web.conf.WebConfiguration;
 import org.eclipse.jetty.servlets.HeaderFilter;
 
@@ -71,7 +72,7 @@ public abstract class WebBundle<T extends Configuration> implements ConfiguredBu
                 .map(entry -> "set " + entry.getKey() + ": " + entry.getValue())
                 .collect(Collectors.joining(","));
         final Map<String, String> filterConfig = Collections.singletonMap("headerConfig", headerConfig);
-        final FilterRegistration.Dynamic filter = environment.servlets()
+        final FilterRegistration.Dynamic filter = getServletEnvironment(environment)
                 .addFilter("header-filter-" + uriPath, HeaderFilter.class);
         filter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, urlPattern);
         filter.setInitParameters(filterConfig);
@@ -83,6 +84,16 @@ public abstract class WebBundle<T extends Configuration> implements ConfiguredBu
         } else {
             return uri + "/" + WILDCARD;
         }
+    }
+
+    /**
+     * Define which {@link ServletEnvironment} should be configured. Default is {@link Environment#servlets()}.
+     *
+     * @param environment The environment of the Dropwizard application
+     * @return The {@link ServletEnvironment} to configure
+     */
+    protected ServletEnvironment getServletEnvironment(Environment environment) {
+        return environment.servlets();
     }
 
     public abstract WebConfiguration getWebConfiguration(T config);

--- a/src/test/java/io/dropwizard/web/test/TestApp.java
+++ b/src/test/java/io/dropwizard/web/test/TestApp.java
@@ -3,6 +3,7 @@ package io.dropwizard.web.test;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
+import io.dropwizard.jetty.setup.ServletEnvironment;
 import io.dropwizard.web.WebBundle;
 import io.dropwizard.web.conf.WebConfiguration;
 
@@ -13,16 +14,27 @@ public class TestApp extends Application<TestConfig> {
 
     @Override
     public void initialize(Bootstrap<TestConfig> bootstrap) {
-        bootstrap.addBundle(new WebBundle<TestConfig>() {
+        bootstrap.addBundle(new WebBundle<>() {
             @Override
             public WebConfiguration getWebConfiguration(TestConfig config) {
                 return config.getWeb1Configuration();
             }
         });
-        bootstrap.addBundle(new WebBundle<TestConfig>() {
+        bootstrap.addBundle(new WebBundle<>() {
             @Override
             public WebConfiguration getWebConfiguration(TestConfig config) {
                 return config.getWeb2Configuration();
+            }
+        });
+        bootstrap.addBundle(new WebBundle<>() {
+            @Override
+            public WebConfiguration getWebConfiguration(TestConfig config) {
+                return config.getAdminWebConfiguration();
+            }
+
+            @Override
+            protected ServletEnvironment getServletEnvironment(Environment environment) {
+                return environment.admin();
             }
         });
     }

--- a/src/test/java/io/dropwizard/web/test/TestConfig.java
+++ b/src/test/java/io/dropwizard/web/test/TestConfig.java
@@ -18,6 +18,11 @@ public class TestConfig extends Configuration {
     @JsonProperty("web2")
     private WebConfiguration web2Configuration = new WebConfiguration();
 
+    @Valid
+    @NotNull
+    @JsonProperty("webAdmin")
+    private WebConfiguration adminWebConfiguration = new WebConfiguration();
+
     public WebConfiguration getWeb1Configuration() {
         return web1Configuration;
     }
@@ -26,11 +31,19 @@ public class TestConfig extends Configuration {
         return web2Configuration;
     }
 
+    public WebConfiguration getAdminWebConfiguration() {
+        return adminWebConfiguration;
+    }
+
     public void setWeb1Configuration(WebConfiguration webConfiguration) {
         this.web1Configuration = webConfiguration;
     }
 
     public void setWeb2Configuration(WebConfiguration webConfiguration) {
         this.web2Configuration = webConfiguration;
+    }
+
+    public void setAdminWebConfiguration(WebConfiguration adminWebConfiguration) {
+        this.adminWebConfiguration = adminWebConfiguration;
     }
 }

--- a/src/test/java/io/dropwizard/web/test/WebFilterIT.java
+++ b/src/test/java/io/dropwizard/web/test/WebFilterIT.java
@@ -21,11 +21,13 @@ public class WebFilterIT {
 
     private Client client;
     private String hostUrl;
+    private String adminUrl;
 
     @BeforeEach
     public void setUp() throws Exception {
         client = EXT.client();
         hostUrl = "http://localhost:" + EXT.getLocalPort();
+        adminUrl = "http://localhost:" + EXT.getAdminPort() + "/admin";
     }
 
     @AfterEach
@@ -38,10 +40,12 @@ public class WebFilterIT {
         // given
         String uri1 = hostUrl + "/test/one";
         String uri2 = hostUrl + "/test/two";
+        String adminUri = adminUrl + "/ping";
 
         // when
         Response response1 = client.target(uri1).request().get();
         Response response2 = client.target(uri2).request().get();
+        Response adminResponse = client.target(adminUri).request().get();
 
         // then
         assertThat(response1.readEntity(String.class), is("test response 1"));
@@ -54,6 +58,7 @@ public class WebFilterIT {
         assertThat(response1.getHeaderString("X-Custom-Header-2"), is("custom value 2"));
         assertThat(response2.readEntity(String.class), is("test response 2"));
         assertThat(response2.getHeaderString("X-Second-Custom-Header"), is("custom value"));
+        assertThat(adminResponse.getHeaderString("X-Admin-Custom-Header"), is("custom value"));
     }
 
 }

--- a/src/test/resources/conf/config.yml
+++ b/src/test/resources/conf/config.yml
@@ -21,7 +21,11 @@ web2:
   headers:
     enabled: true
     X-Second-Custom-Header: custom value
-
+webAdmin:
+  uriPath: /
+  headers:
+    enabled: true
+    X-Admin-Custom-Header: custom value
 server:
   type: simple
   applicationContextPath: /


### PR DESCRIPTION
The new `WebBundle#getServletEnvironment(Environment)` method allows for specifying a different `ServletEnvironment` to which dropwizard-web should be applied.

Refs #383