### PR TITLE
Remove maven-failsafe-plugin from pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,16 +92,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.5</version>
-        </plugin>
-        <plugin>
           <groupId>com.github.github</groupId>
           <artifactId>site-maven-plugin</artifactId>
           <version>0.12</version>


### PR DESCRIPTION
maven-failsafe-plugin is managed via `io.dropwizard.modules:module-parent`.